### PR TITLE
Fix baseurl and permalink relative path issues

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,6 +1,6 @@
 <meta name="description" content="{% if page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
     <link rel="shortcut icon" href="{{ site.url }}{{ site.baseurl }}{{ site.favicon }}" type="image/png" />
-    <link rel="canonical" href="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove: '/' }}" />
+    <link rel="canonical" href="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}" />
     <meta name="referrer" content="no-referrer-when-downgrade" />
 
     {% if page.content and page.current == 'post' or page.current == 'about' %}
@@ -10,7 +10,7 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="{% if title %}{{ title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
     <meta property="og:description" content="{% if excerpt %}{{ excerpt }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
-    <meta property="og:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove: '/' }}" />
+    <meta property="og:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}" />
     <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}{{ site.cover }}{% endif %}" />
     <meta property="article:publisher" content="https://www.facebook.com/{{ site.facebook }}" />{% if excerpt %}
     <meta property="article:author" content="https://www.facebook.com/{{ site.facebook }}" />
@@ -42,7 +42,7 @@
         "name": "{{ site.title }}",
         "logo": "{{ site.url }}{{ site.baseurl }}{{ site.logo }}"
     },
-    "url": "{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove: '/' }}",
+    "url": "{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}",
     "image": {
         "@type": "ImageObject",
         "url": "{{ site.url }}{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}{{ site.cover }}{% endif %}",
@@ -51,7 +51,7 @@
     },
     "mainEntityOfPage": {
         "@type": "WebPage",
-        "@id": "{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove: '/' }}"
+        "@id": "{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}"
     },
     "description": "{% if excerpt %}{{ excerpt }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}"
 }

--- a/_includes/post-card-error.html
+++ b/_includes/post-card-error.html
@@ -4,12 +4,12 @@
     {% if count <= 3 %}
         <article class="post-card {{ page.class }}{% unless post.cover %} no-image{% endunless %}">
             {% if post.cover %}
-                <a class="post-card-image-link" href="{{ site.baseurl }}{{ post.url | remove: '/' }}">
+                <a class="post-card-image-link" href="{{ site.baseurl }}{{ post.url | remove_first: '/' }}">
                     <div class="post-card-image" style="background-image: url({{ site.baseurl }}{{ post.cover }})"></div>
                 </a>
             {% endif %}
             <div class="post-card-content">
-                <a class="post-card-content-link" href="{{ site.baseurl }}{{ post.url | remove: '/' }}">
+                <a class="post-card-content-link" href="{{ site.baseurl }}{{ post.url | remove_first: '/' }}">
                     <header class="post-card-header">
                         {% if post.tags.size > 0 %}
                             {% for tag in post.tags %}

--- a/_includes/post-card-next.html
+++ b/_includes/post-card-next.html
@@ -1,12 +1,12 @@
 
     <article class="post-card {{ page.next.class }}{% unless page.next.cover %} no-image{% endunless %}">
         {% if page.next.cover %}
-            <a class="post-card-image-link" href="{{ site.baseurl }}{{ page.next.url | remove: '/' }}">
+            <a class="post-card-image-link" href="{{ site.baseurl }}{{ page.next.url | remove_first: '/' }}">
                 <div class="post-card-image" style="background-image: url({{ site.baseurl }}{{ page.next.cover }})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">
-            <a class="post-card-content-link" href="{{ site.baseurl }}{{ page.next.url | remove: '/' }}">
+            <a class="post-card-content-link" href="{{ site.baseurl }}{{ page.next.url | remove_first: '/' }}">
                 <header class="post-card-header">
                     {% if page.next.tags.size > 0 %}
                         {% for tag in page.next.tags %}

--- a/_includes/post-card-previous.html
+++ b/_includes/post-card-previous.html
@@ -1,12 +1,12 @@
 
     <article class="post-card {{ page.previous.class }}{% unless page.previous.cover %} no-image{% endunless %}">
         {% if page.previous.cover %}
-            <a class="post-card-image-link" href="{{ site.baseurl }}{{ page.previous.url | remove: '/' }}">
+            <a class="post-card-image-link" href="{{ site.baseurl }}{{ page.previous.url | remove_first: '/' }}">
                 <div class="post-card-image" style="background-image: url({{ site.baseurl }}{{ page.previous.cover }})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">
-            <a class="post-card-content-link" href="{{ site.baseurl }}{{ page.previous.url | remove: '/' }}">
+            <a class="post-card-content-link" href="{{ site.baseurl }}{{ page.previous.url | remove_first: '/' }}">
                 <header class="post-card-header">
                     {% if page.previous.tags.size > 0 %}
                         {% for tag in page.previous.tags %}

--- a/_includes/post-card.html
+++ b/_includes/post-card.html
@@ -1,12 +1,12 @@
 {% for post in paginator.posts %}
     <article class="post-card {{ page.class }}{% unless post.cover %} no-image{% endunless %}">
         {% if post.cover %}
-            <a class="post-card-image-link" href="{{ site.baseurl }}{{ post.url | remove: '/' }}">
+            <a class="post-card-image-link" href="{{ site.baseurl }}{{ post.url | remove_first: '/' }}">
                 <div class="post-card-image" style="background-image: url({{ site.baseurl }}{{ post.cover }})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">
-            <a class="post-card-content-link" href="{{ site.baseurl }}{{ post.url | remove: '/' }}">
+            <a class="post-card-content-link" href="{{ site.baseurl }}{{ post.url | remove_first: '/' }}">
                 <header class="post-card-header">
                     {% if post.tags.size > 0 %}
                         {% for tag in post.tags %}

--- a/_layouts/author.xml
+++ b/_layouts/author.xml
@@ -5,14 +5,14 @@ title: nil
 {% for post in page.posts %}
 	<item>
 	  <title>{{ post.title }}</title>
-	  <link>{{ site.url }}{{ site.baseurl }}{{ post.url | remove: '/' }}</link>
+	  <link>{{ site.url }}{{ site.baseurl }}{{ post.url | remove_first: '/' }}</link>
 		{% for author in site.data.authors %}
 				{% if author[1].username == page.author %}
 						<author>{{ author[1].name }}</author>
 				{% endif %}
 		{% endfor %}
 	  <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
-	  <guid>{{ site.url }}{{ site.baseurl }}{{ post.url | remove: '/' }}</guid>
+	  <guid>{{ site.url }}{{ site.baseurl }}{{ post.url | remove_first: '/' }}</guid>
 	  <description><![CDATA[
 	     {{ post.content | expand_urls : site.url }}
 	  ]]></description>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -151,7 +151,7 @@ into the {body} of the default.hbs template -->
                                     {% if post.title != page.title %}
                                         {% assign count = count | plus: 1 %}
                                         {% if count <= 3 %}
-                                            <li><a href="{{ site.baseurl }}{{ post.url | remove: '/' }}">{{ post.title }}</a></li>
+                                            <li><a href="{{ site.baseurl }}{{ post.url | remove_first: '/' }}">{{ post.title }}</a></li>
                                         {% endif %}
                                     {% endif %}
                                   {% endif %}

--- a/_layouts/tag.xml
+++ b/_layouts/tag.xml
@@ -5,14 +5,14 @@ title: nil
 {% for post in page.posts %}
 	<item>
 	  <title>{{ post.title }}</title>
-	  <link>{{ site.url }}{{ site.baseurl }}{{ post.url | remove: '/' }}</link>
+	  <link>{{ site.url }}{{ site.baseurl }}{{ post.url | remove_first: '/' }}</link>
 		{% for author in site.data.authors %}
 				{% if author[1].username == post.author %}
 						<author>{{ author[1].name }}</author>
 				{% endif %}
 		{% endfor %}
 	  <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
-	  <guid>{{ site.url }}{{ site.baseurl }}{{ post.url | remove: '/' }}</guid>
+	  <guid>{{ site.url }}{{ site.baseurl }}{{ post.url | remove_first: '/' }}</guid>
 	  <description><![CDATA[
 	     {{ post.content | expand_urls : site.url }}
 	  ]]></description>


### PR DESCRIPTION
Replaces `remove: '/'` to `remove_first: '/'` when preceded by
site.baseurl.

Attempting to build a site with permalinks within a subdirectory
generates incorrect links. Links with a leading slash were being
interpreted as a complete link with a relative schema because another
slash was being added to the URL.  Slashes in links are missing when
using permalink schemes other than /:title because all '/' characters
were being removed from the pathname.

To alleviate this, we only remove the first '/' to keep browsers from
misinterpreting the path as an absolute URL. Now, all permalink schemes
work as intended.

This should hopefully fix all, if not most cases.