### PR TITLE
Make AutGenerator get posts by author.

### DIFF
--- a/_plugins/jekyll-autgenerator.rb
+++ b/_plugins/jekyll-autgenerator.rb
@@ -6,7 +6,7 @@ module Jekyll
 
     def generate(site)
       site.data['authors'].each do |author, data|
-        posts = [author, posts_by_author(author)]
+        posts = [author, posts_by_author(site, author)]
         build_subpages(site, 'author', posts)
       end
     end
@@ -40,7 +40,7 @@ module Jekyll
 
     private
 
-    def posts_by_author(author)
+    def posts_by_author(site, author)
       site.posts.docs.select { |post| post.data['author'] == author }
     end
   end

--- a/_plugins/jekyll-autgenerator.rb
+++ b/_plugins/jekyll-autgenerator.rb
@@ -5,8 +5,9 @@ module Jekyll
     safe true
 
     def generate(site)
-      site.categories.each do |author|
-        build_subpages(site, "author", author)
+      site.data['authors'].each do |author, data|
+        posts = [author, posts_by_author(author)]
+        build_subpages(site, 'author', posts)
       end
     end
 
@@ -35,6 +36,12 @@ module Jekyll
         site.pages << newpage
 
       end
+    end
+
+    private
+
+    def posts_by_author(author)
+      site.posts.docs.select { |post| post.data['author'] == author }
     end
   end
 


### PR DESCRIPTION
Hi, I just noticed that the author pages were being generated by fetching the posts by categories. Which had to be a duplicate of the correspondent `site.data.authors`. It introduced some friction and I had to look very thoroughly to be able to create a new author. I think this should reduce the problems for people trying to use this theme in the future. Cheers!