### PR TITLE
Don't load an external stylesheet in 404 page

### DIFF
--- a/404.html
+++ b/404.html
@@ -17,8 +17,8 @@ It's a good idea to keep this template as minimal as possible in terms of both f
     <title>{{ page.title }}</title>
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}assets/css/screen.css" />
-    <link rel="stylesheet" type="text/css" href="https://demo.ghost.io/assets/built/screen.css?v=724281a32e" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}assets/built/screen.css" />
+    <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}assets/built/screen.edited.css" />
     <!-- This tag outputs SEO meta+structured data and other important settings -->
     {% include head.html %}
 </head>


### PR DESCRIPTION
Before this commit the non-built css as well as an external css page
from the ghost project would be loaded on the 404 page. We should load
the same local css as the rest of the pages.